### PR TITLE
Install on ensure latest when it is not installed

### DIFF
--- a/lib/puppet/provider/package/snap.rb
+++ b/lib/puppet/provider/package/snap.rb
@@ -78,6 +78,10 @@ Puppet::Type.type(:package).provide :snap, :parent => Puppet::Provider::Package 
   end
 
   def update
+    unless self.query
+      return self.install
+    end
+
     installer "refresh", @resource[:name]
   end
 end


### PR DESCRIPTION
Turns out there was a bug so that the provider tried to update a package even though it was not installed.
I added a is installed check in the update method and let it run the install method if it is not installed.